### PR TITLE
Family's Member list not need to order

### DIFF
--- a/genogram/src/main/kotlin/ffc/genogram/Family.kt
+++ b/genogram/src/main/kotlin/ffc/genogram/Family.kt
@@ -22,15 +22,16 @@ import ffc.genogram.Util.cleanUpEmptyStack
 class Family(
         var familyId: Long,
         var familyName: String,
-        var members: List<Person>
+        var members: List<Person>,
+        rootPerson: Person = members[0]
 ) {
     var bloodFamily: MutableList<Int>?
 
     init {
         require(members.isNotEmpty()) { "member should not empty" }
 
-        bloodFamily = mutableListOf(members[0].idCard)
-        bloodFamily!!.addDescendentOf(members[0])
+        bloodFamily = mutableListOf(rootPerson.idCard)
+        bloodFamily!!.addDescendentOf(rootPerson)
     }
 
     private fun MutableList<Int>.addDescendentOf(head: Person) {

--- a/genogram/src/main/kotlin/ffc/genogram/FamilyTreeDrawer.kt
+++ b/genogram/src/main/kotlin/ffc/genogram/FamilyTreeDrawer.kt
@@ -241,6 +241,7 @@ class FamilyTreeDrawer {
     }
 
     fun getPersonLayerInd(layerNumb: Int, index: Int): Person? {
+
         val element = personFamilyStorage[layerNumb][index]
         return element as? Person
     }
@@ -249,8 +250,7 @@ class FamilyTreeDrawer {
         // Check the person gender, and find the person's
         val allPeople: MutableList<Int> = mutableListOf()
         personFamilyStorage[layerNumb - 1].forEach {
-            if (it is Person)
-                allPeople.add(it.idCard)
+            if (it is Person) allPeople.add(it.idCard)
         }
 
         // find the focusedPerson and addedPerson's index

--- a/genogram/src/main/kotlin/ffc/genogram/Person.kt
+++ b/genogram/src/main/kotlin/ffc/genogram/Person.kt
@@ -142,25 +142,23 @@ class Person(
     }
 
     // and remove children's id out of the parents' link stack
-    fun popChildren(childrenIdList: MutableList<Int>, person2: Person?, familyMembers: List<Person>?)
+    fun popChildren(childrenIdList: MutableList<Int>, person2: Person?, familyMembers: List<Person>)
             : ArrayList<Person> {
 
-        val childrenList: ArrayList<Person> = arrayListOf()
-
-        familyMembers!!.forEach { child ->
-            childrenIdList.find { it == child.idCard.toInt() }?.let {
-                val tmp = child.linkedStack as MutableList<Int>
+        val children = arrayListOf<Person>()
+        childrenIdList.mapTo(arrayListOf()) {
+            familyMembers.find { member -> member.idCard == it }?.let { member ->
+                val tmp = member.linkedStack as MutableList<Int>
                 // remove the child father/mother
-                tmp.remove(idCard.toInt())
+                tmp.remove(idCard)
                 if (person2 != null)
-                    tmp.remove(person2.idCard.toInt())
+                    tmp.remove(person2.idCard)
 
-                child.linkedStack = cleanUpEmptyStack(tmp)
-                childrenList.add(child)
+                member.linkedStack = cleanUpEmptyStack(tmp)
+                children.add(member)
             }
         }
-
-        return childrenList
+        return children
     }
 
     fun setNodeMargin(siblings: Boolean) {

--- a/genogram/src/test/kotlin/ffc/genogram/BloodFamilyTest.kt
+++ b/genogram/src/test/kotlin/ffc/genogram/BloodFamilyTest.kt
@@ -1,6 +1,7 @@
 package ffc.genogram
 
 import org.amshove.kluent.`should equal`
+import org.amshove.kluent.`should not equal`
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
@@ -26,6 +27,17 @@ class BloodFamilyTest(private val resource: String, private val expectBloodFamil
     @Test
     fun bloodFamily() {
         val family = Family(1, "Smiths", getResourceAs<Family>(resource).members)
+
+        family.bloodFamily!! `should equal` expectBloodFamily
+    }
+
+    @Test
+    fun specifyRootPerson() {
+        val members = getResourceAs<Family>(resource).members
+        val disorder = members.sortedByDescending { it.idCard }
+        disorder `should not equal` members
+
+        val family = Family(1, "Smiths", disorder, rootPerson = members[0])
 
         family.bloodFamily!! `should equal` expectBloodFamily
     }

--- a/samples/android/src/main/java/ffc/genogram/android/sample/MainActivity.kt
+++ b/samples/android/src/main/java/ffc/genogram/android/sample/MainActivity.kt
@@ -31,6 +31,7 @@ import android.view.ViewGroup
 import android.widget.AdapterView
 import android.widget.AdapterView.OnItemSelectedListener
 import android.widget.ArrayAdapter
+import android.widget.Toast
 import com.otaliastudios.zoom.ZoomLayout
 import ffc.genogram.android.GenogramView
 import kotlinx.android.synthetic.main.activity_main.spinner
@@ -44,7 +45,11 @@ class MainActivity : AppCompatActivity() {
             "3 gen 4 child #7" to R.raw.family_4_children_3rd_gen_7,
             "3 gen 7 child" to R.raw.family_7_children_3rd_gen,
             "2 gen 2 spouses #6" to R.raw.family_2_spouses_6,
-            "2 gen 2 spouses #13" to R.raw.family_2_spouses_13
+            "2 gen 2 spouses #13" to R.raw.family_2_spouses_13,
+            "In Family we trust 2018 (easy-1)" to R.raw.in_family_we_trust_2018_easy_1,
+            "In Family we trust 2018 (easy-2)" to R.raw.in_family_we_trust_2018_easy_2,
+            "In Family we trust 2018 (Simple)" to R.raw.in_family_we_trust_2018_simple,
+            "In Family we trust 2018" to R.raw.in_family_we_trust_2018
     )
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -108,12 +113,20 @@ class MainActivity : AppCompatActivity() {
             val families = RawResourceFamilies(context!!, arguments!!.getInt(ARG_RAW))
             families.family {
                 onSuccess {
-                    val view = GenogramView(context!!)
-                    view.nodeBuilder = SampleNodeBuilder()
-                    view.drawFamily(it)
-
-                    container.addView(view)
-                    Handler().postDelayed({ container.zoomOut() }, 150)
+                    try {
+                        val view = GenogramView(context!!)
+                        view.nodeBuilder = SampleNodeBuilder()
+                        view.drawFamily(it)
+                        container.addView(view)
+                        Handler().postDelayed({ container.zoomOut() }, 150)
+                    } catch (it: Exception) {
+                        Toast.makeText(context, "${it.javaClass.name}: ${it.message}", Toast.LENGTH_SHORT).show()
+                        it.printStackTrace()
+                    }
+                }
+                onFail {
+                    Toast.makeText(context, it?.message, Toast.LENGTH_SHORT).show()
+                    it?.printStackTrace()
                 }
             }
         }

--- a/samples/android/src/main/java/ffc/genogram/android/sample/RawResourceFamilies.kt
+++ b/samples/android/src/main/java/ffc/genogram/android/sample/RawResourceFamilies.kt
@@ -31,11 +31,7 @@ class RawResourceFamilies(val context: Context, @RawRes val rawId: Int) : Famili
     override fun family(callbackDsl: Families.Callback.() -> Unit) {
         val callback = Families.Callback().apply(callbackDsl)
         Handler().postDelayed({
-            try {
                 callback.onSuccess(context.rawAs<Family>(rawId))
-            } catch (exception: Exception) {
-                callback.onFail(exception)
-            }
         }, 500)
     }
 }

--- a/samples/android/src/main/res/raw/in_family_we_trust_2018.json
+++ b/samples/android/src/main/res/raw/in_family_we_trust_2018.json
@@ -1,0 +1,1157 @@
+{
+  "bloodFamily": [
+    1393414347,
+    1670030195,
+    200451287,
+    1607161586,
+    1801386413,
+    1868639714,
+    169646432,
+    549450420,
+    313875492,
+    183547297,
+    752893399,
+    1912831964,
+    1912757006,
+    305814635,
+    381432301,
+    1509256505
+  ],
+  "familyId": 0,
+  "familyName": "จิระอนันต์",
+  "members": [
+    {
+      "linkedStack": [
+        281033158,
+        1670030195,
+        200451287,
+        1607161586,
+        1801386413,
+        1868639714
+      ],
+      "properties": {
+        "identities": [],
+        "chronics": [],
+        "relationships": [
+          {
+            "relate": "Married",
+            "id": "{{อาม่า}}",
+            "name": "อาม่า จิระอนันต์"
+          },
+          {
+            "relate": "Child",
+            "id": "{{ประเสริฐ}}",
+            "name": "ประเสริฐ จิระอนันต์"
+          },
+          {
+            "relate": "Child",
+            "id": "{{เมธ}}",
+            "name": "เมธ จิระอนันต์"
+          },
+          {
+            "relate": "Child",
+            "id": "{{ภัสสร}}",
+            "name": "ภัสสร จิระอนันต์"
+          },
+          {
+            "relate": "Child",
+            "id": "{{มนฤดี}}",
+            "name": "มนฤดี จิระอนันต์"
+          },
+          {
+            "relate": "Child",
+            "id": "{{กรกันต์}}",
+            "name": "กรกันต์ จิระอนันต์"
+          }
+        ],
+        "prename": "",
+        "firstname": "อากง",
+        "lastname": "จิระอนันต์",
+        "sex": "MALE",
+        "houseId": "{{house_id_for_geno}}",
+        "id": "{{อากง}}",
+        "type": "Person",
+        "timestamp": "2018-11-08T11:02:35.161+07:00"
+      },
+      "nodeMargin": 0,
+      "idCard": 1393414347,
+      "firstname": "อากง",
+      "lastname": "จิระอนันต์",
+      "gender": "0",
+      "wife": [
+        281033158
+      ],
+      "children": [
+        1670030195,
+        200451287,
+        1607161586,
+        1801386413,
+        1868639714
+      ]
+    },
+    {
+      "linkedStack": [
+        1393414347,
+        1670030195,
+        200451287,
+        1607161586,
+        1801386413,
+        1868639714
+      ],
+      "properties": {
+        "identities": [],
+        "chronics": [],
+        "relationships": [
+          {
+            "relate": "Married",
+            "id": "{{อากง}}",
+            "name": "อากง จิระอนันต์"
+          },
+          {
+            "relate": "Child",
+            "id": "{{ประเสริฐ}}",
+            "name": "ประเสริฐ จิระอนันต์"
+          },
+          {
+            "relate": "Child",
+            "id": "{{เมธ}}",
+            "name": "เมธ จิระอนันต์"
+          },
+          {
+            "relate": "Child",
+            "id": "{{ภัสสร}}",
+            "name": "ภัสสร จิระอนันต์"
+          },
+          {
+            "relate": "Child",
+            "id": "{{มนฤดี}}",
+            "name": "มนฤดี จิระอนันต์"
+          },
+          {
+            "relate": "Child",
+            "id": "{{กรกันต์}}",
+            "name": "กรกันต์ จิระอนันต์"
+          }
+        ],
+        "prename": "",
+        "firstname": "อาม่า",
+        "lastname": "จิระอนันต์",
+        "sex": "FEMALE",
+        "houseId": "{{house_id_for_geno}}",
+        "id": "{{อาม่า}}",
+        "type": "Person",
+        "timestamp": "2018-11-08T11:02:35.223+07:00"
+      },
+      "nodeMargin": 0,
+      "idCard": 281033158,
+      "firstname": "อาม่า",
+      "lastname": "จิระอนันต์",
+      "gender": "1",
+      "husband": [
+        1393414347
+      ],
+      "children": [
+        1670030195,
+        200451287,
+        1607161586,
+        1801386413,
+        1868639714
+      ]
+    },
+    {
+      "linkedStack": [
+        1393414347,
+        281033158,
+        356973275,
+        381432301,
+        1509256505
+      ],
+      "properties": {
+        "identities": [],
+        "chronics": [],
+        "relationships": [
+          {
+            "relate": "Father",
+            "id": "{{อากง}}",
+            "name": "อากง จิระอนันต์"
+          },
+          {
+            "relate": "Mother",
+            "id": "{{อาม่า}}",
+            "name": "อาม่า จิระอนันต์"
+          },
+          {
+            "relate": "Married",
+            "id": "{{น้ำผึ้ง}}",
+            "name": "น้ำผึ้ง จิระอนันต์"
+          },
+          {
+            "relate": "Child",
+            "id": "{{เวกัส}}",
+            "name": "เวกัส จิระอนันต์"
+          },
+          {
+            "relate": "Child",
+            "id": "{{มาเก๋า}}",
+            "name": "มาเก๋า จิระอนันต์"
+          },
+          {
+            "relate": "Sibling",
+            "id": "{{ประเสริฐ}}",
+            "name": "ประเสริฐ จิระอนันต์"
+          },
+          {
+            "relate": "Sibling",
+            "id": "{{เมธ}}",
+            "name": "เมธ จิระอนันต์"
+          },
+          {
+            "relate": "Sibling",
+            "id": "{{ภัสสร}}",
+            "name": "ภัสสร จิระอนันต์"
+          },
+          {
+            "relate": "Sibling",
+            "id": "{{มนฤดี}}",
+            "name": "มนฤดี จิระอนันต์"
+          }
+        ],
+        "prename": "",
+        "firstname": "กรกันต์",
+        "lastname": "จิระอนันต์",
+        "sex": "MALE",
+        "houseId": "{{house_id_for_geno}}",
+        "id": "{{กรกันต์}}",
+        "type": "Person",
+        "timestamp": "2018-11-08T11:02:35.223+07:00"
+      },
+      "nodeMargin": 0,
+      "idCard": 1868639714,
+      "firstname": "กรกันต์",
+      "lastname": "จิระอนันต์",
+      "gender": "0",
+      "father": 1393414347,
+      "mother": 281033158,
+      "wife": [
+        356973275
+      ],
+      "children": [
+        381432301,
+        1509256505
+      ]
+    },
+    {
+      "linkedStack": [
+        1393414347,
+        281033158,
+        313875492
+      ],
+      "properties": {
+        "identities": [],
+        "chronics": [],
+        "relationships": [
+          {
+            "relate": "Father",
+            "id": "{{อากง}}",
+            "name": "อากง จิระอนันต์"
+          },
+          {
+            "relate": "Mother",
+            "id": "{{อาม่า}}",
+            "name": "อาม่า จิระอนันต์"
+          },
+          {
+            "relate": "Child",
+            "id": "{{เหม่เหม}}",
+            "name": "เหม่เหม จิระอนันต์"
+          },
+          {
+            "relate": "Sibling",
+            "id": "{{ประเสริฐ}}",
+            "name": "ประเสริฐ จิระอนันต์"
+          },
+          {
+            "relate": "Sibling",
+            "id": "{{ภัสสร}}",
+            "name": "ภัสสร จิระอนันต์"
+          },
+          {
+            "relate": "Sibling",
+            "id": "{{มนฤดี}}",
+            "name": "มนฤดี จิระอนันต์"
+          },
+          {
+            "relate": "Sibling",
+            "id": "{{กรกันต์}}",
+            "name": "กรกันต์ จิระอนันต์"
+          }
+        ],
+        "prename": "",
+        "firstname": "เมธ",
+        "lastname": "จิระอนันต์",
+        "sex": "MALE",
+        "houseId": "{{house_id_for_geno}}",
+        "id": "{{เมธ}}",
+        "type": "Person",
+        "timestamp": "2018-11-08T11:02:35.223+07:00"
+      },
+      "nodeMargin": 0,
+      "idCard": 200451287,
+      "firstname": "เมธ",
+      "lastname": "จิระอนันต์",
+      "gender": "0",
+      "father": 1393414347,
+      "mother": 281033158,
+      "children": [
+        313875492
+      ]
+    },
+    {
+      "linkedStack": [
+        1670030195,
+        169646432
+      ],
+      "properties": {
+        "identities": [],
+        "chronics": [],
+        "relationships": [
+          {
+            "relate": "Married",
+            "id": "{{ประเสริฐ}}",
+            "name": "ประเสริฐ จิระอนันต์"
+          },
+          {
+            "relate": "Child",
+            "id": "{{พีท}}",
+            "name": "พีท จิระอนันต์"
+          }
+        ],
+        "prename": "",
+        "firstname": "คริส",
+        "lastname": "จิระอนันต์",
+        "sex": "FEMALE",
+        "houseId": "{{house_id_for_geno}}",
+        "id": "{{คริส}}",
+        "type": "Person",
+        "timestamp": "2018-11-08T11:02:35.223+07:00"
+      },
+      "nodeMargin": 0,
+      "idCard": 207319317,
+      "firstname": "คริส",
+      "lastname": "จิระอนันต์",
+      "gender": "1",
+      "husband": [
+        1670030195
+      ],
+      "children": [
+        169646432
+      ]
+    },
+    {
+      "linkedStack": [
+        1393414347,
+        281033158,
+        305814635
+      ],
+      "properties": {
+        "identities": [],
+        "chronics": [],
+        "relationships": [
+          {
+            "relate": "Father",
+            "id": "{{อากง}}",
+            "name": "อากง จิระอนันต์"
+          },
+          {
+            "relate": "Mother",
+            "id": "{{อาม่า}}",
+            "name": "อาม่า จิระอนันต์"
+          },
+          {
+            "relate": "Child",
+            "id": "{{ก๋วยเตี๋ยว}}",
+            "name": "ก๋วยเตี๋ยว จิระอนันต์"
+          }
+        ],
+        "prename": "",
+        "firstname": "มนฤดี",
+        "lastname": "จิระอนันต์",
+        "sex": "FEMALE",
+        "houseId": "{{house_id_for_geno}}",
+        "id": "{{มนฤดี}}",
+        "type": "Person",
+        "timestamp": "2018-11-08T11:02:35.223+07:00"
+      },
+      "nodeMargin": 0,
+      "idCard": 1801386413,
+      "firstname": "มนฤดี",
+      "lastname": "จิระอนันต์",
+      "gender": "1",
+      "father": 1393414347,
+      "mother": 281033158,
+      "children": [
+        305814635
+      ]
+    },
+    {
+      "linkedStack": [
+        1393414347,
+        281033158,
+        823643213,
+        169646432,
+        549450420
+      ],
+      "properties": {
+        "identities": [],
+        "chronics": [],
+        "relationships": [
+          {
+            "relate": "Father",
+            "id": "{{อากง}}",
+            "name": "อากง จิระอนันต์"
+          },
+          {
+            "relate": "Mother",
+            "id": "{{อาม่า}}",
+            "name": "อาม่า จิระอนันต์"
+          },
+          {
+            "relate": "Divorced",
+            "id": "{{คริส}}",
+            "name": "คริส จิระอนันต์"
+          },
+          {
+            "relate": "Child",
+            "id": "{{พีท}}",
+            "name": "พีท จิระอนันต์"
+          },
+          {
+            "relate": "Married",
+            "id": "{{นิภา}}",
+            "name": "นิภา จิระอนันต์"
+          },
+          {
+            "relate": "Child",
+            "id": "{{ฉี}}",
+            "name": "ฉี จิระอนันต์"
+          },
+          {
+            "relate": "Sibling",
+            "id": "{{เมธ}}",
+            "name": "เมธ จิระอนันต์"
+          },
+          {
+            "relate": "Sibling",
+            "id": "{{ภัสสร}}",
+            "name": "ภัสสร จิระอนันต์"
+          },
+          {
+            "relate": "Sibling",
+            "id": "{{มนฤดี}}",
+            "name": "มนฤดี จิระอนันต์"
+          },
+          {
+            "relate": "Sibling",
+            "id": "{{กรกันต์}}",
+            "name": "กรกันต์ จิระอนันต์"
+          }
+        ],
+        "prename": "",
+        "firstname": "ประเสริฐ",
+        "lastname": "จิระอนันต์",
+        "sex": "MALE",
+        "houseId": "{{house_id_for_geno}}",
+        "id": "{{ประเสริฐ}}",
+        "type": "Person",
+        "timestamp": "2018-11-08T11:02:35.223+07:00"
+      },
+      "nodeMargin": 0,
+      "idCard": 1670030195,
+      "firstname": "ประเสริฐ",
+      "lastname": "จิระอนันต์",
+      "gender": "0",
+      "father": 1393414347,
+      "mother": 281033158,
+      "wife": [
+        823643213
+      ],
+      "children": [
+        169646432,
+        549450420
+      ]
+    },
+    {
+      "linkedStack": [
+        1393414347,
+        281033158,
+        1013365983,
+        183547297,
+        752893399,
+        1912831964,
+        1912757006
+      ],
+      "properties": {
+        "identities": [],
+        "chronics": [],
+        "relationships": [
+          {
+            "relate": "Father",
+            "id": "{{อากง}}",
+            "name": "อากง จิระอนันต์"
+          },
+          {
+            "relate": "Mother",
+            "id": "{{อาม่า}}",
+            "name": "อาม่า จิระอนันต์"
+          },
+          {
+            "relate": "Married",
+            "id": "{{วิเชียร}}",
+            "name": "วิเชียร จิระอนันต์"
+          },
+          {
+            "relate": "Child",
+            "id": "{{อี้}}",
+            "name": "อี้ จิระอนันต์"
+          },
+          {
+            "relate": "Child",
+            "id": "{{เอิร์น}}",
+            "name": "เอิร์น จิระอนันต์"
+          },
+          {
+            "relate": "Child",
+            "id": "{{เต๋า}}",
+            "name": "เต๋า จิระอนันต์"
+          },
+          {
+            "relate": "Child",
+            "id": "{{เต้ย}}",
+            "name": "เต้ย จิระอนันต์"
+          },
+          {
+            "relate": "Sibling",
+            "id": "{{ประเสริฐ}}",
+            "name": "ประเสริฐ จิระอนันต์"
+          },
+          {
+            "relate": "Sibling",
+            "id": "{{เมธ}}",
+            "name": "เมธ จิระอนันต์"
+          },
+          {
+            "relate": "Sibling",
+            "id": "{{มนฤดี}}",
+            "name": "มนฤดี จิระอนันต์"
+          },
+          {
+            "relate": "Sibling",
+            "id": "{{กรกันต์}}",
+            "name": "กรกันต์ จิระอนันต์"
+          }
+        ],
+        "prename": "",
+        "firstname": "ภัสสร",
+        "lastname": "จิระอนันต์",
+        "sex": "FEMALE",
+        "houseId": "{{house_id_for_geno}}",
+        "id": "{{ภัสสร}}",
+        "type": "Person",
+        "timestamp": "2018-11-08T11:02:35.223+07:00"
+      },
+      "nodeMargin": 0,
+      "idCard": 1607161586,
+      "firstname": "ภัสสร",
+      "lastname": "จิระอนันต์",
+      "gender": "1",
+      "father": 1393414347,
+      "mother": 281033158,
+      "husband": [
+        1013365983
+      ],
+      "children": [
+        183547297,
+        752893399,
+        1912831964,
+        1912757006
+      ]
+    },
+    {
+      "linkedStack": [
+        1607161586,
+        183547297,
+        752893399,
+        1912831964,
+        1912757006
+      ],
+      "properties": {
+        "identities": [],
+        "chronics": [],
+        "relationships": [
+          {
+            "relate": "Married",
+            "id": "{{ภัสสร}}",
+            "name": "ภัสสร จิระอนันต์"
+          },
+          {
+            "relate": "Child",
+            "id": "{{อี้}}",
+            "name": "อี้ จิระอนันต์"
+          },
+          {
+            "relate": "Child",
+            "id": "{{เอิร์น}}",
+            "name": "เอิร์น จิระอนันต์"
+          },
+          {
+            "relate": "Child",
+            "id": "{{เต๋า}}",
+            "name": "เต๋า จิระอนันต์"
+          },
+          {
+            "relate": "Child",
+            "id": "{{เต้ย}}",
+            "name": "เต้ย จิระอนันต์"
+          }
+        ],
+        "prename": "",
+        "firstname": "วิเชียร",
+        "lastname": "จิระอนันต์",
+        "sex": "MALE",
+        "houseId": "{{house_id_for_geno}}",
+        "id": "{{วิเชียร}}",
+        "type": "Person",
+        "timestamp": "2018-11-08T11:02:35.223+07:00"
+      },
+      "nodeMargin": 0,
+      "idCard": 1013365983,
+      "firstname": "วิเชียร",
+      "lastname": "จิระอนันต์",
+      "gender": "0",
+      "wife": [
+        1607161586
+      ],
+      "children": [
+        183547297,
+        752893399,
+        1912831964,
+        1912757006
+      ]
+    },
+    {
+      "linkedStack": [
+        1670030195,
+        549450420
+      ],
+      "properties": {
+        "identities": [],
+        "chronics": [],
+        "relationships": [
+          {
+            "relate": "Married",
+            "id": "{{ประเสริฐ}}",
+            "name": "ประเสริฐ จิระอนันต์"
+          },
+          {
+            "relate": "Child",
+            "id": "{{ฉี}}",
+            "name": "ฉี จิระอนันต์"
+          }
+        ],
+        "prename": "",
+        "firstname": "นิภา",
+        "lastname": "จิระอนันต์",
+        "sex": "FEMALE",
+        "houseId": "{{house_id_for_geno}}",
+        "id": "{{นิภา}}",
+        "type": "Person",
+        "timestamp": "2018-11-08T11:02:35.223+07:00"
+      },
+      "nodeMargin": 0,
+      "idCard": 823643213,
+      "firstname": "นิภา",
+      "lastname": "จิระอนันต์",
+      "gender": "1",
+      "husband": [
+        1670030195
+      ],
+      "children": [
+        549450420
+      ]
+    },
+    {
+      "linkedStack": [
+        1868639714,
+        381432301,
+        1509256505
+      ],
+      "properties": {
+        "identities": [],
+        "chronics": [],
+        "relationships": [
+          {
+            "relate": "Married",
+            "id": "{{กรกันต์}}",
+            "name": "กรกันต์ จิระอนันต์"
+          },
+          {
+            "relate": "Child",
+            "id": "{{เวกัส}}",
+            "name": "เวกัส จิระอนันต์"
+          },
+          {
+            "relate": "Child",
+            "id": "{{มาเก๋า}}",
+            "name": "มาเก๋า จิระอนันต์"
+          }
+        ],
+        "prename": "",
+        "firstname": "น้ำผึ้ง",
+        "lastname": "จิระอนันต์",
+        "sex": "FEMALE",
+        "houseId": "{{house_id_for_geno}}",
+        "id": "{{น้ำผึ้ง}}",
+        "type": "Person",
+        "timestamp": "2018-11-08T11:02:35.223+07:00"
+      },
+      "nodeMargin": 0,
+      "idCard": 356973275,
+      "firstname": "น้ำผึ้ง",
+      "lastname": "จิระอนันต์",
+      "gender": "1",
+      "husband": [
+        1868639714
+      ],
+      "children": [
+        381432301,
+        1509256505
+      ]
+    },
+    {
+      "linkedStack": [
+        1670030195,
+        823643213
+      ],
+      "properties": {
+        "identities": [],
+        "chronics": [],
+        "relationships": [
+          {
+            "relate": "Father",
+            "id": "{{ประเสริฐ}}",
+            "name": "ประเสริฐ จิระอนันต์"
+          },
+          {
+            "relate": "Mother",
+            "id": "{{นิภา}}",
+            "name": "นิภา จิระอนันต์"
+          }
+        ],
+        "prename": "",
+        "firstname": "ฉี",
+        "lastname": "จิระอนันต์",
+        "sex": "MALE",
+        "houseId": "{{house_id_for_geno}}",
+        "id": "{{ฉี}}",
+        "type": "Person",
+        "timestamp": "2018-11-08T11:02:35.223+07:00"
+      },
+      "nodeMargin": 0,
+      "idCard": 549450420,
+      "firstname": "ฉี",
+      "lastname": "จิระอนันต์",
+      "gender": "0",
+      "father": 1670030195,
+      "mother": 823643213
+    },
+    {
+      "linkedStack": [
+        1013365983,
+        1607161586
+      ],
+      "properties": {
+        "identities": [],
+        "chronics": [],
+        "relationships": [
+          {
+            "relate": "Father",
+            "id": "{{วิเชียร}}",
+            "name": "วิเชียร จิระอนันต์"
+          },
+          {
+            "relate": "Mother",
+            "id": "{{ภัสสร}}",
+            "name": "ภัสสร จิระอนันต์"
+          },
+          {
+            "relate": "Sibling",
+            "id": "{{อี้}}",
+            "name": "อี้ จิระอนันต์"
+          },
+          {
+            "relate": "Sibling",
+            "id": "{{เอิร์น}}",
+            "name": "เอิร์น จิระอนันต์"
+          },
+          {
+            "relate": "Sibling",
+            "id": "{{เต๋า}}",
+            "name": "เต๋า จิระอนันต์"
+          }
+        ],
+        "prename": "",
+        "firstname": "เต้ย",
+        "lastname": "จิระอนันต์",
+        "sex": "MALE",
+        "houseId": "{{house_id_for_geno}}",
+        "id": "{{เต้ย}}",
+        "type": "Person",
+        "timestamp": "2018-11-08T11:02:35.223+07:00"
+      },
+      "nodeMargin": 0,
+      "idCard": 1912757006,
+      "firstname": "เต้ย",
+      "lastname": "จิระอนันต์",
+      "gender": "0",
+      "father": 1013365983,
+      "mother": 1607161586
+    },
+    {
+      "linkedStack": [
+        1868639714,
+        356973275
+      ],
+      "properties": {
+        "identities": [],
+        "chronics": [],
+        "relationships": [
+          {
+            "relate": "Father",
+            "id": "{{กรกันต์}}",
+            "name": "กรกันต์ จิระอนันต์"
+          },
+          {
+            "relate": "Mother",
+            "id": "{{น้ำผึ้ง}}",
+            "name": "น้ำผึ้ง จิระอนันต์"
+          },
+          {
+            "relate": "Sibling",
+            "id": "{{เวกัส}}",
+            "name": "เวกัส จิระอนันต์"
+          }
+        ],
+        "prename": "",
+        "firstname": "มาเก๋า",
+        "lastname": "จิระอนันต์",
+        "sex": "MALE",
+        "houseId": "{{house_id_for_geno}}",
+        "id": "{{มาเก๋า}}",
+        "type": "Person",
+        "timestamp": "2018-11-08T11:02:35.223+07:00"
+      },
+      "nodeMargin": 0,
+      "idCard": 1509256505,
+      "firstname": "มาเก๋า",
+      "lastname": "จิระอนันต์",
+      "gender": "0",
+      "father": 1868639714,
+      "mother": 356973275
+    },
+    {
+      "linkedStack": [
+        1868639714,
+        356973275
+      ],
+      "properties": {
+        "identities": [],
+        "chronics": [],
+        "relationships": [
+          {
+            "relate": "Father",
+            "id": "{{กรกันต์}}",
+            "name": "กรกันต์ จิระอนันต์"
+          },
+          {
+            "relate": "Mother",
+            "id": "{{น้ำผึ้ง}}",
+            "name": "น้ำผึ้ง จิระอนันต์"
+          },
+          {
+            "relate": "Sibling",
+            "id": "{{มาเก๋า}}",
+            "name": "มาเก๋า จิระอนันต์"
+          }
+        ],
+        "prename": "",
+        "firstname": "เวกัส",
+        "lastname": "จิระอนันต์",
+        "sex": "MALE",
+        "houseId": "{{house_id_for_geno}}",
+        "id": "{{เวกัส}}",
+        "type": "Person",
+        "timestamp": "2018-11-08T11:02:35.223+07:00"
+      },
+      "nodeMargin": 0,
+      "idCard": 381432301,
+      "firstname": "เวกัส",
+      "lastname": "จิระอนันต์",
+      "gender": "0",
+      "father": 1868639714,
+      "mother": 356973275
+    },
+    {
+      "linkedStack": [
+        1801386413
+      ],
+      "properties": {
+        "identities": [],
+        "chronics": [],
+        "relationships": [
+          {
+            "relate": "Father",
+            "id": "{{มนฤดี}}",
+            "name": "มนฤดี จิระอนันต์"
+          }
+        ],
+        "prename": "",
+        "firstname": "ก๋วยเตี๋ยว",
+        "lastname": "จิระอนันต์",
+        "sex": "MALE",
+        "houseId": "{{house_id_for_geno}}",
+        "id": "{{ก๋วยเตี๋ยว}}",
+        "type": "Person",
+        "timestamp": "2018-11-08T11:02:35.223+07:00"
+      },
+      "nodeMargin": 0,
+      "idCard": 305814635,
+      "firstname": "ก๋วยเตี๋ยว",
+      "lastname": "จิระอนันต์",
+      "gender": "0",
+      "father": 1801386413
+    },
+    {
+      "linkedStack": [
+        200451287
+      ],
+      "properties": {
+        "identities": [],
+        "chronics": [],
+        "relationships": [
+          {
+            "relate": "Father",
+            "id": "{{เมธ}}",
+            "name": "เมธ จิระอนันต์"
+          }
+        ],
+        "prename": "",
+        "firstname": "เหม่เหม",
+        "lastname": "จิระอนันต์",
+        "sex": "FEMALE",
+        "houseId": "{{house_id_for_geno}}",
+        "id": "{{เหม่เหม}}",
+        "type": "Person",
+        "timestamp": "2018-11-08T11:02:35.223+07:00"
+      },
+      "nodeMargin": 0,
+      "idCard": 313875492,
+      "firstname": "เหม่เหม",
+      "lastname": "จิระอนันต์",
+      "gender": "1",
+      "father": 200451287
+    },
+    {
+      "linkedStack": [
+        1013365983,
+        1607161586
+      ],
+      "properties": {
+        "identities": [],
+        "chronics": [],
+        "relationships": [
+          {
+            "relate": "Father",
+            "id": "{{วิเชียร}}",
+            "name": "วิเชียร จิระอนันต์"
+          },
+          {
+            "relate": "Mother",
+            "id": "{{ภัสสร}}",
+            "name": "ภัสสร จิระอนันต์"
+          },
+          {
+            "relate": "Sibling",
+            "id": "{{เอิร์น}}",
+            "name": "เอิร์น จิระอนันต์"
+          },
+          {
+            "relate": "Sibling",
+            "id": "{{เต๋า}}",
+            "name": "เต๋า จิระอนันต์"
+          },
+          {
+            "relate": "Sibling",
+            "id": "{{เต้ย}}",
+            "name": "เต้ย จิระอนันต์"
+          }
+        ],
+        "prename": "",
+        "firstname": "อี้",
+        "lastname": "จิระอนันต์",
+        "sex": "MALE",
+        "houseId": "{{house_id_for_geno}}",
+        "id": "{{อี้}}",
+        "type": "Person",
+        "timestamp": "2018-11-08T11:02:35.223+07:00"
+      },
+      "nodeMargin": 0,
+      "idCard": 183547297,
+      "firstname": "อี้",
+      "lastname": "จิระอนันต์",
+      "gender": "0",
+      "father": 1013365983,
+      "mother": 1607161586
+    },
+    {
+      "linkedStack": [
+        1013365983,
+        1607161586
+      ],
+      "properties": {
+        "identities": [],
+        "chronics": [],
+        "relationships": [
+          {
+            "relate": "Father",
+            "id": "{{วิเชียร}}",
+            "name": "วิเชียร จิระอนันต์"
+          },
+          {
+            "relate": "Mother",
+            "id": "{{ภัสสร}}",
+            "name": "ภัสสร จิระอนันต์"
+          },
+          {
+            "relate": "Sibling",
+            "id": "{{อี้}}",
+            "name": "อี้ จิระอนันต์"
+          },
+          {
+            "relate": "Sibling",
+            "id": "{{เต๋า}}",
+            "name": "เต๋า จิระอนันต์"
+          },
+          {
+            "relate": "Sibling",
+            "id": "{{เต้ย}}",
+            "name": "เต้ย จิระอนันต์"
+          }
+        ],
+        "prename": "",
+        "firstname": "เอิร์น",
+        "lastname": "จิระอนันต์",
+        "sex": "MALE",
+        "houseId": "{{house_id_for_geno}}",
+        "id": "{{เอิร์น}}",
+        "type": "Person",
+        "timestamp": "2018-11-08T11:02:35.223+07:00"
+      },
+      "nodeMargin": 0,
+      "idCard": 752893399,
+      "firstname": "เอิร์น",
+      "lastname": "จิระอนันต์",
+      "gender": "0",
+      "father": 1013365983,
+      "mother": 1607161586
+    },
+    {
+      "linkedStack": [
+        1670030195,
+        207319317
+      ],
+      "properties": {
+        "identities": [],
+        "chronics": [],
+        "relationships": [
+          {
+            "relate": "Father",
+            "id": "{{ประเสริฐ}}",
+            "name": "ประเสริฐ จิระอนันต์"
+          },
+          {
+            "relate": "Mother",
+            "id": "{{คริส}}",
+            "name": "คริส จิระอนันต์"
+          }
+        ],
+        "prename": "",
+        "firstname": "พีท",
+        "lastname": "จิระอนันต์",
+        "sex": "MALE",
+        "houseId": "{{house_id_for_geno}}",
+        "id": "{{พีท}}",
+        "type": "Person",
+        "timestamp": "2018-11-08T11:02:35.223+07:00"
+      },
+      "nodeMargin": 0,
+      "idCard": 169646432,
+      "firstname": "พีท",
+      "lastname": "จิระอนันต์",
+      "gender": "0",
+      "father": 1670030195,
+      "mother": 207319317
+    },
+    {
+      "linkedStack": [
+        1013365983,
+        1607161586
+      ],
+      "properties": {
+        "identities": [],
+        "chronics": [],
+        "relationships": [
+          {
+            "relate": "Father",
+            "id": "{{วิเชียร}}",
+            "name": "วิเชียร จิระอนันต์"
+          },
+          {
+            "relate": "Mother",
+            "id": "{{ภัสสร}}",
+            "name": "ภัสสร จิระอนันต์"
+          },
+          {
+            "relate": "Sibling",
+            "id": "{{อี้}}",
+            "name": "อี้ จิระอนันต์"
+          },
+          {
+            "relate": "Sibling",
+            "id": "{{เอิร์น}}",
+            "name": "เอิร์น จิระอนันต์"
+          },
+          {
+            "relate": "Sibling",
+            "id": "{{เต้ย}}",
+            "name": "เต้ย จิระอนันต์"
+          }
+        ],
+        "prename": "",
+        "firstname": "เต๋า",
+        "lastname": "จิระอนันต์",
+        "sex": "MALE",
+        "houseId": "{{house_id_for_geno}}",
+        "id": "{{เต๋า}}",
+        "type": "Person",
+        "timestamp": "2018-11-08T11:02:35.223+07:00"
+      },
+      "nodeMargin": 0,
+      "idCard": 1912831964,
+      "firstname": "เต๋า",
+      "lastname": "จิระอนันต์",
+      "gender": "0",
+      "father": 1013365983,
+      "mother": 1607161586
+    }
+  ]
+}

--- a/samples/android/src/main/res/raw/in_family_we_trust_2018_easy_1.json
+++ b/samples/android/src/main/res/raw/in_family_we_trust_2018_easy_1.json
@@ -1,0 +1,442 @@
+{
+  "bloodFamily": [
+    1393414347,
+    1607161586,
+    183547297,
+    752893399,
+    1912831964,
+    1912757006
+  ],
+  "familyId": 0,
+  "familyName": "จิระอนันต์",
+  "members": [
+    {
+      "linkedStack": [
+        281033158,
+        1607161586
+      ],
+      "properties": {
+        "identities": [],
+        "chronics": [],
+        "relationships": [
+          {
+            "relate": "Married",
+            "id": "{{อาม่า}}",
+            "name": "อาม่า จิระอนันต์"
+          },
+          {
+            "relate": "Child",
+            "id": "{{ภัสสร}}",
+            "name": "ภัสสร จิระอนันต์"
+          }
+        ],
+        "prename": "",
+        "firstname": "อากง",
+        "lastname": "จิระอนันต์",
+        "sex": "MALE",
+        "houseId": "{{house_id_for_geno}}",
+        "id": "{{อากง}}",
+        "type": "Person",
+        "timestamp": "2018-11-08T11:31:53.152+07:00"
+      },
+      "nodeMargin": 0,
+      "idCard": 1393414347,
+      "firstname": "อากง",
+      "lastname": "จิระอนันต์",
+      "gender": "0",
+      "wife": [
+        281033158
+      ],
+      "children": [
+        1607161586
+      ]
+    },
+    {
+      "linkedStack": [
+        1393414347,
+        1607161586
+      ],
+      "properties": {
+        "identities": [],
+        "chronics": [],
+        "relationships": [
+          {
+            "relate": "Married",
+            "id": "{{อากง}}",
+            "name": "อากง จิระอนันต์"
+          },
+          {
+            "relate": "Child",
+            "id": "{{ภัสสร}}",
+            "name": "ภัสสร จิระอนันต์"
+          }
+        ],
+        "prename": "",
+        "firstname": "อาม่า",
+        "lastname": "จิระอนันต์",
+        "sex": "FEMALE",
+        "houseId": "{{house_id_for_geno}}",
+        "id": "{{อาม่า}}",
+        "type": "Person",
+        "timestamp": "2018-11-08T11:31:53.246+07:00"
+      },
+      "nodeMargin": 0,
+      "idCard": 281033158,
+      "firstname": "อาม่า",
+      "lastname": "จิระอนันต์",
+      "gender": "1",
+      "husband": [
+        1393414347
+      ],
+      "children": [
+        1607161586
+      ]
+    },
+    {
+      "linkedStack": [
+        1607161586,
+        183547297,
+        752893399,
+        1912831964,
+        1912757006
+      ],
+      "properties": {
+        "identities": [],
+        "chronics": [],
+        "relationships": [
+          {
+            "relate": "Married",
+            "id": "{{ภัสสร}}",
+            "name": "ภัสสร จิระอนันต์"
+          },
+          {
+            "relate": "Child",
+            "id": "{{อี้}}",
+            "name": "อี้ จิระอนันต์"
+          },
+          {
+            "relate": "Child",
+            "id": "{{เอิร์น}}",
+            "name": "เอิร์น จิระอนันต์"
+          },
+          {
+            "relate": "Child",
+            "id": "{{เต๋า}}",
+            "name": "เต๋า จิระอนันต์"
+          },
+          {
+            "relate": "Child",
+            "id": "{{เต้ย}}",
+            "name": "เต้ย จิระอนันต์"
+          }
+        ],
+        "prename": "",
+        "firstname": "วิเชียร",
+        "lastname": "จิระอนันต์",
+        "sex": "MALE",
+        "houseId": "{{house_id_for_geno}}",
+        "id": "{{วิเชียร}}",
+        "type": "Person",
+        "timestamp": "2018-11-08T11:31:53.246+07:00"
+      },
+      "nodeMargin": 0,
+      "idCard": 1013365983,
+      "firstname": "วิเชียร",
+      "lastname": "จิระอนันต์",
+      "gender": "0",
+      "wife": [
+        1607161586
+      ],
+      "children": [
+        183547297,
+        752893399,
+        1912831964,
+        1912757006
+      ]
+    },
+    {
+      "linkedStack": [
+        1393414347,
+        281033158,
+        1013365983,
+        183547297,
+        752893399,
+        1912831964,
+        1912757006
+      ],
+      "properties": {
+        "identities": [],
+        "chronics": [],
+        "relationships": [
+          {
+            "relate": "Father",
+            "id": "{{อากง}}",
+            "name": "อากง จิระอนันต์"
+          },
+          {
+            "relate": "Mother",
+            "id": "{{อาม่า}}",
+            "name": "อาม่า จิระอนันต์"
+          },
+          {
+            "relate": "Married",
+            "id": "{{วิเชียร}}",
+            "name": "วิเชียร จิระอนันต์"
+          },
+          {
+            "relate": "Child",
+            "id": "{{อี้}}",
+            "name": "อี้ จิระอนันต์"
+          },
+          {
+            "relate": "Child",
+            "id": "{{เอิร์น}}",
+            "name": "เอิร์น จิระอนันต์"
+          },
+          {
+            "relate": "Child",
+            "id": "{{เต๋า}}",
+            "name": "เต๋า จิระอนันต์"
+          },
+          {
+            "relate": "Child",
+            "id": "{{เต้ย}}",
+            "name": "เต้ย จิระอนันต์"
+          }
+        ],
+        "prename": "",
+        "firstname": "ภัสสร",
+        "lastname": "จิระอนันต์",
+        "sex": "FEMALE",
+        "houseId": "{{house_id_for_geno}}",
+        "id": "{{ภัสสร}}",
+        "type": "Person",
+        "timestamp": "2018-11-08T11:31:53.246+07:00"
+      },
+      "nodeMargin": 0,
+      "idCard": 1607161586,
+      "firstname": "ภัสสร",
+      "lastname": "จิระอนันต์",
+      "gender": "1",
+      "father": 1393414347,
+      "mother": 281033158,
+      "husband": [
+        1013365983
+      ],
+      "children": [
+        183547297,
+        752893399,
+        1912831964,
+        1912757006
+      ]
+    },
+    {
+      "linkedStack": [
+        1013365983,
+        1607161586
+      ],
+      "properties": {
+        "identities": [],
+        "chronics": [],
+        "relationships": [
+          {
+            "relate": "Father",
+            "id": "{{วิเชียร}}",
+            "name": "วิเชียร จิระอนันต์"
+          },
+          {
+            "relate": "Mother",
+            "id": "{{ภัสสร}}",
+            "name": "ภัสสร จิระอนันต์"
+          },
+          {
+            "relate": "Sibling",
+            "id": "{{เอิร์น}}",
+            "name": "เอิร์น จิระอนันต์"
+          },
+          {
+            "relate": "Sibling",
+            "id": "{{เต๋า}}",
+            "name": "เต๋า จิระอนันต์"
+          },
+          {
+            "relate": "Sibling",
+            "id": "{{เต้ย}}",
+            "name": "เต้ย จิระอนันต์"
+          }
+        ],
+        "prename": "",
+        "firstname": "อี้",
+        "lastname": "จิระอนันต์",
+        "sex": "MALE",
+        "houseId": "{{house_id_for_geno}}",
+        "id": "{{อี้}}",
+        "type": "Person",
+        "timestamp": "2018-11-08T11:31:53.246+07:00"
+      },
+      "nodeMargin": 0,
+      "idCard": 183547297,
+      "firstname": "อี้",
+      "lastname": "จิระอนันต์",
+      "gender": "0",
+      "father": 1013365983,
+      "mother": 1607161586
+    },
+    {
+      "linkedStack": [
+        1013365983,
+        1607161586
+      ],
+      "properties": {
+        "identities": [],
+        "chronics": [],
+        "relationships": [
+          {
+            "relate": "Father",
+            "id": "{{วิเชียร}}",
+            "name": "วิเชียร จิระอนันต์"
+          },
+          {
+            "relate": "Mother",
+            "id": "{{ภัสสร}}",
+            "name": "ภัสสร จิระอนันต์"
+          },
+          {
+            "relate": "Sibling",
+            "id": "{{อี้}}",
+            "name": "อี้ จิระอนันต์"
+          },
+          {
+            "relate": "Sibling",
+            "id": "{{เต๋า}}",
+            "name": "เต๋า จิระอนันต์"
+          },
+          {
+            "relate": "Sibling",
+            "id": "{{เต้ย}}",
+            "name": "เต้ย จิระอนันต์"
+          }
+        ],
+        "prename": "",
+        "firstname": "เอิร์น",
+        "lastname": "จิระอนันต์",
+        "sex": "MALE",
+        "houseId": "{{house_id_for_geno}}",
+        "id": "{{เอิร์น}}",
+        "type": "Person",
+        "timestamp": "2018-11-08T11:31:53.246+07:00"
+      },
+      "nodeMargin": 0,
+      "idCard": 752893399,
+      "firstname": "เอิร์น",
+      "lastname": "จิระอนันต์",
+      "gender": "0",
+      "father": 1013365983,
+      "mother": 1607161586
+    },
+    {
+      "linkedStack": [
+        1013365983,
+        1607161586
+      ],
+      "properties": {
+        "identities": [],
+        "chronics": [],
+        "relationships": [
+          {
+            "relate": "Father",
+            "id": "{{วิเชียร}}",
+            "name": "วิเชียร จิระอนันต์"
+          },
+          {
+            "relate": "Mother",
+            "id": "{{ภัสสร}}",
+            "name": "ภัสสร จิระอนันต์"
+          },
+          {
+            "relate": "Sibling",
+            "id": "{{อี้}}",
+            "name": "อี้ จิระอนันต์"
+          },
+          {
+            "relate": "Sibling",
+            "id": "{{เอิร์น}}",
+            "name": "เอิร์น จิระอนันต์"
+          },
+          {
+            "relate": "Sibling",
+            "id": "{{เต๋า}}",
+            "name": "เต๋า จิระอนันต์"
+          }
+        ],
+        "prename": "",
+        "firstname": "เต้ย",
+        "lastname": "จิระอนันต์",
+        "sex": "MALE",
+        "houseId": "{{house_id_for_geno}}",
+        "id": "{{เต้ย}}",
+        "type": "Person",
+        "timestamp": "2018-11-08T11:31:53.248+07:00"
+      },
+      "nodeMargin": 0,
+      "idCard": 1912757006,
+      "firstname": "เต้ย",
+      "lastname": "จิระอนันต์",
+      "gender": "0",
+      "father": 1013365983,
+      "mother": 1607161586
+    },
+    {
+      "linkedStack": [
+        1013365983,
+        1607161586
+      ],
+      "properties": {
+        "identities": [],
+        "chronics": [],
+        "relationships": [
+          {
+            "relate": "Father",
+            "id": "{{วิเชียร}}",
+            "name": "วิเชียร จิระอนันต์"
+          },
+          {
+            "relate": "Mother",
+            "id": "{{ภัสสร}}",
+            "name": "ภัสสร จิระอนันต์"
+          },
+          {
+            "relate": "Sibling",
+            "id": "{{อี้}}",
+            "name": "อี้ จิระอนันต์"
+          },
+          {
+            "relate": "Sibling",
+            "id": "{{เอิร์น}}",
+            "name": "เอิร์น จิระอนันต์"
+          },
+          {
+            "relate": "Sibling",
+            "id": "{{เต้ย}}",
+            "name": "เต้ย จิระอนันต์"
+          }
+        ],
+        "prename": "",
+        "firstname": "เต๋า",
+        "lastname": "จิระอนันต์",
+        "sex": "MALE",
+        "houseId": "{{house_id_for_geno}}",
+        "id": "{{เต๋า}}",
+        "type": "Person",
+        "timestamp": "2018-11-08T11:31:53.247+07:00"
+      },
+      "nodeMargin": 0,
+      "idCard": 1912831964,
+      "firstname": "เต๋า",
+      "lastname": "จิระอนันต์",
+      "gender": "0",
+      "father": 1013365983,
+      "mother": 1607161586
+    }
+  ]
+}

--- a/samples/android/src/main/res/raw/in_family_we_trust_2018_easy_2.json
+++ b/samples/android/src/main/res/raw/in_family_we_trust_2018_easy_2.json
@@ -1,0 +1,545 @@
+{
+  "bloodFamily": [
+    1393414347,
+    1607161586,
+    1868639714,
+    183547297,
+    752893399,
+    1912831964,
+    1912757006
+  ],
+  "familyId": 0,
+  "familyName": "จิระอนันต์",
+  "members": [
+    {
+      "linkedStack": [
+        281033158,
+        1607161586,
+        1868639714
+      ],
+      "properties": {
+        "identities": [],
+        "chronics": [],
+        "relationships": [
+          {
+            "relate": "Married",
+            "id": "{{อาม่า}}",
+            "name": "อาม่า จิระอนันต์"
+          },
+          {
+            "relate": "Child",
+            "id": "{{ภัสสร}}",
+            "name": "ภัสสร จิระอนันต์"
+          },
+          {
+            "relate": "Child",
+            "id": "{{กรกันต์}}",
+            "name": "กรกันต์ จิระอนันต์"
+          }
+        ],
+        "prename": "",
+        "firstname": "อากง",
+        "lastname": "จิระอนันต์",
+        "sex": "MALE",
+        "houseId": "{{house_id_for_geno}}",
+        "id": "{{อากง}}",
+        "type": "Person",
+        "timestamp": "2018-11-08T11:46:15.438+07:00"
+      },
+      "nodeMargin": 0,
+      "idCard": 1393414347,
+      "firstname": "อากง",
+      "lastname": "จิระอนันต์",
+      "gender": "0",
+      "wife": [
+        281033158
+      ],
+      "children": [
+        1607161586,
+        1868639714
+      ]
+    },
+    {
+      "linkedStack": [
+        1393414347,
+        1607161586,
+        1868639714
+      ],
+      "properties": {
+        "identities": [],
+        "chronics": [],
+        "relationships": [
+          {
+            "relate": "Married",
+            "id": "{{อากง}}",
+            "name": "อากง จิระอนันต์"
+          },
+          {
+            "relate": "Child",
+            "id": "{{ภัสสร}}",
+            "name": "ภัสสร จิระอนันต์"
+          },
+          {
+            "relate": "Child",
+            "id": "{{กรกันต์}}",
+            "name": "กรกันต์ จิระอนันต์"
+          }
+        ],
+        "prename": "",
+        "firstname": "อาม่า",
+        "lastname": "จิระอนันต์",
+        "sex": "FEMALE",
+        "houseId": "{{house_id_for_geno}}",
+        "id": "{{อาม่า}}",
+        "type": "Person",
+        "timestamp": "2018-11-08T11:46:15.513+07:00"
+      },
+      "nodeMargin": 0,
+      "idCard": 281033158,
+      "firstname": "อาม่า",
+      "lastname": "จิระอนันต์",
+      "gender": "1",
+      "husband": [
+        1393414347
+      ],
+      "children": [
+        1607161586,
+        1868639714
+      ]
+    },
+    {
+      "linkedStack": [
+        1393414347,
+        281033158,
+        356973275
+      ],
+      "properties": {
+        "identities": [],
+        "chronics": [],
+        "relationships": [
+          {
+            "relate": "Father",
+            "id": "{{อากง}}",
+            "name": "อากง จิระอนันต์"
+          },
+          {
+            "relate": "Mother",
+            "id": "{{อาม่า}}",
+            "name": "อาม่า จิระอนันต์"
+          },
+          {
+            "relate": "Married",
+            "id": "{{น้ำผึ้ง}}",
+            "name": "น้ำผึ้ง จิระอนันต์"
+          },
+          {
+            "relate": "Sibling",
+            "id": "{{ภัสสร}}",
+            "name": "ภัสสร จิระอนันต์"
+          }
+        ],
+        "prename": "",
+        "firstname": "กรกันต์",
+        "lastname": "จิระอนันต์",
+        "sex": "MALE",
+        "houseId": "{{house_id_for_geno}}",
+        "id": "{{กรกันต์}}",
+        "type": "Person",
+        "timestamp": "2018-11-08T11:46:15.514+07:00"
+      },
+      "nodeMargin": 0,
+      "idCard": 1868639714,
+      "firstname": "กรกันต์",
+      "lastname": "จิระอนันต์",
+      "gender": "0",
+      "father": 1393414347,
+      "mother": 281033158,
+      "wife": [
+        356973275
+      ]
+    },
+    {
+      "linkedStack": [
+        1607161586,
+        183547297,
+        752893399,
+        1912831964,
+        1912757006
+      ],
+      "properties": {
+        "identities": [],
+        "chronics": [],
+        "relationships": [
+          {
+            "relate": "Married",
+            "id": "{{ภัสสร}}",
+            "name": "ภัสสร จิระอนันต์"
+          },
+          {
+            "relate": "Child",
+            "id": "{{อี้}}",
+            "name": "อี้ จิระอนันต์"
+          },
+          {
+            "relate": "Child",
+            "id": "{{เอิร์น}}",
+            "name": "เอิร์น จิระอนันต์"
+          },
+          {
+            "relate": "Child",
+            "id": "{{เต๋า}}",
+            "name": "เต๋า จิระอนันต์"
+          },
+          {
+            "relate": "Child",
+            "id": "{{เต้ย}}",
+            "name": "เต้ย จิระอนันต์"
+          }
+        ],
+        "prename": "",
+        "firstname": "วิเชียร",
+        "lastname": "จิระอนันต์",
+        "sex": "MALE",
+        "houseId": "{{house_id_for_geno}}",
+        "id": "{{วิเชียร}}",
+        "type": "Person",
+        "timestamp": "2018-11-08T11:46:15.514+07:00"
+      },
+      "nodeMargin": 0,
+      "idCard": 1013365983,
+      "firstname": "วิเชียร",
+      "lastname": "จิระอนันต์",
+      "gender": "0",
+      "children": [
+        183547297,
+        752893399,
+        1912831964,
+        1912757006
+      ],
+      "wife": [
+        1607161586
+      ]
+    },
+    {
+      "linkedStack": [
+        1393414347,
+        281033158,
+        1013365983,
+        183547297,
+        752893399,
+        1912831964,
+        1912757006
+      ],
+      "properties": {
+        "identities": [],
+        "chronics": [],
+        "relationships": [
+          {
+            "relate": "Father",
+            "id": "{{อากง}}",
+            "name": "อากง จิระอนันต์"
+          },
+          {
+            "relate": "Mother",
+            "id": "{{อาม่า}}",
+            "name": "อาม่า จิระอนันต์"
+          },
+          {
+            "relate": "Married",
+            "id": "{{วิเชียร}}",
+            "name": "วิเชียร จิระอนันต์"
+          },
+          {
+            "relate": "Child",
+            "id": "{{อี้}}",
+            "name": "อี้ จิระอนันต์"
+          },
+          {
+            "relate": "Child",
+            "id": "{{เอิร์น}}",
+            "name": "เอิร์น จิระอนันต์"
+          },
+          {
+            "relate": "Child",
+            "id": "{{เต๋า}}",
+            "name": "เต๋า จิระอนันต์"
+          },
+          {
+            "relate": "Child",
+            "id": "{{เต้ย}}",
+            "name": "เต้ย จิระอนันต์"
+          },
+          {
+            "relate": "Sibling",
+            "id": "{{กรกันต์}}",
+            "name": "กรกันต์ จิระอนันต์"
+          }
+        ],
+        "prename": "",
+        "firstname": "ภัสสร",
+        "lastname": "จิระอนันต์",
+        "sex": "FEMALE",
+        "houseId": "{{house_id_for_geno}}",
+        "id": "{{ภัสสร}}",
+        "type": "Person",
+        "timestamp": "2018-11-08T11:46:15.513+07:00"
+      },
+      "nodeMargin": 0,
+      "idCard": 1607161586,
+      "firstname": "ภัสสร",
+      "lastname": "จิระอนันต์",
+      "gender": "1",
+      "father": 1393414347,
+      "mother": 281033158,
+      "husband": [
+        1013365983
+      ],
+      "children": [
+        183547297,
+        752893399,
+        1912831964,
+        1912757006
+      ]
+    },
+    {
+      "linkedStack": [
+        1868639714
+      ],
+      "properties": {
+        "identities": [],
+        "chronics": [],
+        "relationships": [
+          {
+            "relate": "Married",
+            "id": "{{กรกันต์}}",
+            "name": "กรกันต์ จิระอนันต์"
+          }
+        ],
+        "prename": "",
+        "firstname": "น้ำผึ้ง",
+        "lastname": "จิระอนันต์",
+        "sex": "FEMALE",
+        "houseId": "{{house_id_for_geno}}",
+        "id": "{{น้ำผึ้ง}}",
+        "type": "Person",
+        "timestamp": "2018-11-08T11:46:15.514+07:00"
+      },
+      "nodeMargin": 0,
+      "idCard": 356973275,
+      "firstname": "น้ำผึ้ง",
+      "lastname": "จิระอนันต์",
+      "gender": "1",
+      "husband": [
+        1868639714
+      ]
+    },
+    {
+      "linkedStack": [
+        1013365983,
+        1607161586
+      ],
+      "properties": {
+        "identities": [],
+        "chronics": [],
+        "relationships": [
+          {
+            "relate": "Father",
+            "id": "{{วิเชียร}}",
+            "name": "วิเชียร จิระอนันต์"
+          },
+          {
+            "relate": "Mother",
+            "id": "{{ภัสสร}}",
+            "name": "ภัสสร จิระอนันต์"
+          },
+          {
+            "relate": "Sibling",
+            "id": "{{เอิร์น}}",
+            "name": "เอิร์น จิระอนันต์"
+          },
+          {
+            "relate": "Sibling",
+            "id": "{{เต๋า}}",
+            "name": "เต๋า จิระอนันต์"
+          },
+          {
+            "relate": "Sibling",
+            "id": "{{เต้ย}}",
+            "name": "เต้ย จิระอนันต์"
+          }
+        ],
+        "prename": "",
+        "firstname": "อี้",
+        "lastname": "จิระอนันต์",
+        "sex": "MALE",
+        "houseId": "{{house_id_for_geno}}",
+        "id": "{{อี้}}",
+        "type": "Person",
+        "timestamp": "2018-11-08T11:46:15.514+07:00"
+      },
+      "nodeMargin": 0,
+      "idCard": 183547297,
+      "firstname": "อี้",
+      "lastname": "จิระอนันต์",
+      "gender": "0",
+      "father": 1013365983,
+      "mother": 1607161586
+    },
+    {
+      "linkedStack": [
+        1013365983,
+        1607161586
+      ],
+      "properties": {
+        "identities": [],
+        "chronics": [],
+        "relationships": [
+          {
+            "relate": "Father",
+            "id": "{{วิเชียร}}",
+            "name": "วิเชียร จิระอนันต์"
+          },
+          {
+            "relate": "Mother",
+            "id": "{{ภัสสร}}",
+            "name": "ภัสสร จิระอนันต์"
+          },
+          {
+            "relate": "Sibling",
+            "id": "{{อี้}}",
+            "name": "อี้ จิระอนันต์"
+          },
+          {
+            "relate": "Sibling",
+            "id": "{{เต๋า}}",
+            "name": "เต๋า จิระอนันต์"
+          },
+          {
+            "relate": "Sibling",
+            "id": "{{เต้ย}}",
+            "name": "เต้ย จิระอนันต์"
+          }
+        ],
+        "prename": "",
+        "firstname": "เอิร์น",
+        "lastname": "จิระอนันต์",
+        "sex": "MALE",
+        "houseId": "{{house_id_for_geno}}",
+        "id": "{{เอิร์น}}",
+        "type": "Person",
+        "timestamp": "2018-11-08T11:46:15.514+07:00"
+      },
+      "nodeMargin": 0,
+      "idCard": 752893399,
+      "firstname": "เอิร์น",
+      "lastname": "จิระอนันต์",
+      "gender": "0",
+      "father": 1013365983,
+      "mother": 1607161586
+    },
+    {
+      "linkedStack": [
+        1013365983,
+        1607161586
+      ],
+      "properties": {
+        "identities": [],
+        "chronics": [],
+        "relationships": [
+          {
+            "relate": "Father",
+            "id": "{{วิเชียร}}",
+            "name": "วิเชียร จิระอนันต์"
+          },
+          {
+            "relate": "Mother",
+            "id": "{{ภัสสร}}",
+            "name": "ภัสสร จิระอนันต์"
+          },
+          {
+            "relate": "Sibling",
+            "id": "{{อี้}}",
+            "name": "อี้ จิระอนันต์"
+          },
+          {
+            "relate": "Sibling",
+            "id": "{{เอิร์น}}",
+            "name": "เอิร์น จิระอนันต์"
+          },
+          {
+            "relate": "Sibling",
+            "id": "{{เต๋า}}",
+            "name": "เต๋า จิระอนันต์"
+          }
+        ],
+        "prename": "",
+        "firstname": "เต้ย",
+        "lastname": "จิระอนันต์",
+        "sex": "MALE",
+        "houseId": "{{house_id_for_geno}}",
+        "id": "{{เต้ย}}",
+        "type": "Person",
+        "timestamp": "2018-11-08T11:46:15.514+07:00"
+      },
+      "nodeMargin": 0,
+      "idCard": 1912757006,
+      "firstname": "เต้ย",
+      "lastname": "จิระอนันต์",
+      "gender": "0",
+      "father": 1013365983,
+      "mother": 1607161586
+    },
+    {
+      "linkedStack": [
+        1013365983,
+        1607161586
+      ],
+      "properties": {
+        "identities": [],
+        "chronics": [],
+        "relationships": [
+          {
+            "relate": "Father",
+            "id": "{{วิเชียร}}",
+            "name": "วิเชียร จิระอนันต์"
+          },
+          {
+            "relate": "Mother",
+            "id": "{{ภัสสร}}",
+            "name": "ภัสสร จิระอนันต์"
+          },
+          {
+            "relate": "Sibling",
+            "id": "{{อี้}}",
+            "name": "อี้ จิระอนันต์"
+          },
+          {
+            "relate": "Sibling",
+            "id": "{{เอิร์น}}",
+            "name": "เอิร์น จิระอนันต์"
+          },
+          {
+            "relate": "Sibling",
+            "id": "{{เต้ย}}",
+            "name": "เต้ย จิระอนันต์"
+          }
+        ],
+        "prename": "",
+        "firstname": "เต๋า",
+        "lastname": "จิระอนันต์",
+        "sex": "MALE",
+        "houseId": "{{house_id_for_geno}}",
+        "id": "{{เต๋า}}",
+        "type": "Person",
+        "timestamp": "2018-11-08T11:46:15.514+07:00"
+      },
+      "nodeMargin": 0,
+      "idCard": 1912831964,
+      "firstname": "เต๋า",
+      "lastname": "จิระอนันต์",
+      "gender": "0",
+      "father": 1013365983,
+      "mother": 1607161586
+    }
+  ]
+}

--- a/samples/android/src/main/res/raw/in_family_we_trust_2018_simple.json
+++ b/samples/android/src/main/res/raw/in_family_we_trust_2018_simple.json
@@ -1,0 +1,663 @@
+{
+  "bloodFamily": [
+    1393414347,
+    1607161586,
+    1868639714,
+    183547297,
+    752893399,
+    1912831964,
+    1912757006,
+    381432301,
+    1509256505
+  ],
+  "familyId": 0,
+  "familyName": "จิระอนันต์",
+  "members": [
+    {
+      "linkedStack": [
+        281033158,
+        1607161586,
+        1868639714
+      ],
+      "properties": {
+        "identities": [],
+        "chronics": [],
+        "relationships": [
+          {
+            "relate": "Married",
+            "id": "{{อาม่า}}",
+            "name": "อาม่า จิระอนันต์"
+          },
+          {
+            "relate": "Child",
+            "id": "{{ภัสสร}}",
+            "name": "ภัสสร จิระอนันต์"
+          },
+          {
+            "relate": "Child",
+            "id": "{{กรกันต์}}",
+            "name": "กรกันต์ จิระอนันต์"
+          }
+        ],
+        "prename": "",
+        "firstname": "อากง",
+        "lastname": "จิระอนันต์",
+        "sex": "MALE",
+        "houseId": "{{house_id_for_geno}}",
+        "id": "{{อากง}}",
+        "type": "Person",
+        "timestamp": "2018-11-08T11:13:32.291+07:00"
+      },
+      "nodeMargin": 0,
+      "idCard": 1393414347,
+      "firstname": "อากง",
+      "lastname": "จิระอนันต์",
+      "gender": "0",
+      "wife": [
+        281033158
+      ],
+      "children": [
+        1607161586,
+        1868639714
+      ]
+    },
+    {
+      "linkedStack": [
+        1393414347,
+        1607161586,
+        1868639714
+      ],
+      "properties": {
+        "identities": [],
+        "chronics": [],
+        "relationships": [
+          {
+            "relate": "Married",
+            "id": "{{อากง}}",
+            "name": "อากง จิระอนันต์"
+          },
+          {
+            "relate": "Child",
+            "id": "{{ภัสสร}}",
+            "name": "ภัสสร จิระอนันต์"
+          },
+          {
+            "relate": "Child",
+            "id": "{{กรกันต์}}",
+            "name": "กรกันต์ จิระอนันต์"
+          }
+        ],
+        "prename": "",
+        "firstname": "อาม่า",
+        "lastname": "จิระอนันต์",
+        "sex": "FEMALE",
+        "houseId": "{{house_id_for_geno}}",
+        "id": "{{อาม่า}}",
+        "type": "Person",
+        "timestamp": "2018-11-08T11:13:32.353+07:00"
+      },
+      "nodeMargin": 0,
+      "idCard": 281033158,
+      "firstname": "อาม่า",
+      "lastname": "จิระอนันต์",
+      "gender": "1",
+      "husband": [
+        1393414347
+      ],
+      "children": [
+        1607161586,
+        1868639714
+      ]
+    },
+    {
+      "linkedStack": [
+        1393414347,
+        281033158,
+        356973275,
+        381432301,
+        1509256505
+      ],
+      "properties": {
+        "identities": [],
+        "chronics": [],
+        "relationships": [
+          {
+            "relate": "Father",
+            "id": "{{อากง}}",
+            "name": "อากง จิระอนันต์"
+          },
+          {
+            "relate": "Mother",
+            "id": "{{อาม่า}}",
+            "name": "อาม่า จิระอนันต์"
+          },
+          {
+            "relate": "Married",
+            "id": "{{น้ำผึ้ง}}",
+            "name": "น้ำผึ้ง จิระอนันต์"
+          },
+          {
+            "relate": "Child",
+            "id": "{{เวกัส}}",
+            "name": "เวกัส จิระอนันต์"
+          },
+          {
+            "relate": "Child",
+            "id": "{{มาเก๋า}}",
+            "name": "มาเก๋า จิระอนันต์"
+          },
+          {
+            "relate": "Sibling",
+            "id": "{{ภัสสร}}",
+            "name": "ภัสสร จิระอนันต์"
+          }
+        ],
+        "prename": "",
+        "firstname": "กรกันต์",
+        "lastname": "จิระอนันต์",
+        "sex": "MALE",
+        "houseId": "{{house_id_for_geno}}",
+        "id": "{{กรกันต์}}",
+        "type": "Person",
+        "timestamp": "2018-11-08T11:13:32.353+07:00"
+      },
+      "nodeMargin": 0,
+      "idCard": 1868639714,
+      "firstname": "กรกันต์",
+      "lastname": "จิระอนันต์",
+      "gender": "0",
+      "father": 1393414347,
+      "mother": 281033158,
+      "wife": [
+        356973275
+      ],
+      "children": [
+        381432301,
+        1509256505
+      ]
+    },
+    {
+      "linkedStack": [
+        1393414347,
+        281033158,
+        1013365983,
+        183547297,
+        752893399,
+        1912831964,
+        1912757006
+      ],
+      "properties": {
+        "identities": [],
+        "chronics": [],
+        "relationships": [
+          {
+            "relate": "Father",
+            "id": "{{อากง}}",
+            "name": "อากง จิระอนันต์"
+          },
+          {
+            "relate": "Mother",
+            "id": "{{อาม่า}}",
+            "name": "อาม่า จิระอนันต์"
+          },
+          {
+            "relate": "Married",
+            "id": "{{วิเชียร}}",
+            "name": "วิเชียร จิระอนันต์"
+          },
+          {
+            "relate": "Child",
+            "id": "{{อี้}}",
+            "name": "อี้ จิระอนันต์"
+          },
+          {
+            "relate": "Child",
+            "id": "{{เอิร์น}}",
+            "name": "เอิร์น จิระอนันต์"
+          },
+          {
+            "relate": "Child",
+            "id": "{{เต๋า}}",
+            "name": "เต๋า จิระอนันต์"
+          },
+          {
+            "relate": "Child",
+            "id": "{{เต้ย}}",
+            "name": "เต้ย จิระอนันต์"
+          },
+          {
+            "relate": "Sibling",
+            "id": "{{กรกันต์}}",
+            "name": "กรกันต์ จิระอนันต์"
+          }
+        ],
+        "prename": "",
+        "firstname": "ภัสสร",
+        "lastname": "จิระอนันต์",
+        "sex": "FEMALE",
+        "houseId": "{{house_id_for_geno}}",
+        "id": "{{ภัสสร}}",
+        "type": "Person",
+        "timestamp": "2018-11-08T11:13:32.353+07:00"
+      },
+      "nodeMargin": 0,
+      "idCard": 1607161586,
+      "firstname": "ภัสสร",
+      "lastname": "จิระอนันต์",
+      "gender": "1",
+      "father": 1393414347,
+      "mother": 281033158,
+      "husband": [
+        1013365983
+      ],
+      "children": [
+        183547297,
+        752893399,
+        1912831964,
+        1912757006
+      ]
+    },
+    {
+      "linkedStack": [
+        1607161586,
+        183547297,
+        752893399,
+        1912831964,
+        1912757006
+      ],
+      "properties": {
+        "identities": [],
+        "chronics": [],
+        "relationships": [
+          {
+            "relate": "Married",
+            "id": "{{ภัสสร}}",
+            "name": "ภัสสร จิระอนันต์"
+          },
+          {
+            "relate": "Child",
+            "id": "{{อี้}}",
+            "name": "อี้ จิระอนันต์"
+          },
+          {
+            "relate": "Child",
+            "id": "{{เอิร์น}}",
+            "name": "เอิร์น จิระอนันต์"
+          },
+          {
+            "relate": "Child",
+            "id": "{{เต๋า}}",
+            "name": "เต๋า จิระอนันต์"
+          },
+          {
+            "relate": "Child",
+            "id": "{{เต้ย}}",
+            "name": "เต้ย จิระอนันต์"
+          }
+        ],
+        "prename": "",
+        "firstname": "วิเชียร",
+        "lastname": "จิระอนันต์",
+        "sex": "MALE",
+        "houseId": "{{house_id_for_geno}}",
+        "id": "{{วิเชียร}}",
+        "type": "Person",
+        "timestamp": "2018-11-08T11:13:32.353+07:00"
+      },
+      "nodeMargin": 0,
+      "idCard": 1013365983,
+      "firstname": "วิเชียร",
+      "lastname": "จิระอนันต์",
+      "gender": "0",
+      "wife": [
+        1607161586
+      ],
+      "children": [
+        183547297,
+        752893399,
+        1912831964,
+        1912757006
+      ]
+    },
+    {
+      "linkedStack": [
+        1868639714,
+        381432301,
+        1509256505
+      ],
+      "properties": {
+        "identities": [],
+        "chronics": [],
+        "relationships": [
+          {
+            "relate": "Married",
+            "id": "{{กรกันต์}}",
+            "name": "กรกันต์ จิระอนันต์"
+          },
+          {
+            "relate": "Child",
+            "id": "{{เวกัส}}",
+            "name": "เวกัส จิระอนันต์"
+          },
+          {
+            "relate": "Child",
+            "id": "{{มาเก๋า}}",
+            "name": "มาเก๋า จิระอนันต์"
+          }
+        ],
+        "prename": "",
+        "firstname": "น้ำผึ้ง",
+        "lastname": "จิระอนันต์",
+        "sex": "FEMALE",
+        "houseId": "{{house_id_for_geno}}",
+        "id": "{{น้ำผึ้ง}}",
+        "type": "Person",
+        "timestamp": "2018-11-08T11:13:32.353+07:00"
+      },
+      "nodeMargin": 0,
+      "idCard": 356973275,
+      "firstname": "น้ำผึ้ง",
+      "lastname": "จิระอนันต์",
+      "gender": "1",
+      "husband": [
+        1868639714
+      ],
+      "children": [
+        381432301,
+        1509256505
+      ]
+    },
+    {
+      "linkedStack": [
+        1868639714,
+        356973275
+      ],
+      "properties": {
+        "identities": [],
+        "chronics": [],
+        "relationships": [
+          {
+            "relate": "Father",
+            "id": "{{กรกันต์}}",
+            "name": "กรกันต์ จิระอนันต์"
+          },
+          {
+            "relate": "Mother",
+            "id": "{{น้ำผึ้ง}}",
+            "name": "น้ำผึ้ง จิระอนันต์"
+          },
+          {
+            "relate": "Sibling",
+            "id": "{{มาเก๋า}}",
+            "name": "มาเก๋า จิระอนันต์"
+          }
+        ],
+        "prename": "",
+        "firstname": "เวกัส",
+        "lastname": "จิระอนันต์",
+        "sex": "MALE",
+        "houseId": "{{house_id_for_geno}}",
+        "id": "{{เวกัส}}",
+        "type": "Person",
+        "timestamp": "2018-11-08T11:13:32.353+07:00"
+      },
+      "nodeMargin": 0,
+      "idCard": 381432301,
+      "firstname": "เวกัส",
+      "lastname": "จิระอนันต์",
+      "gender": "0",
+      "father": 1868639714,
+      "mother": 356973275
+    },
+    {
+      "linkedStack": [
+        1013365983,
+        1607161586
+      ],
+      "properties": {
+        "identities": [],
+        "chronics": [],
+        "relationships": [
+          {
+            "relate": "Father",
+            "id": "{{วิเชียร}}",
+            "name": "วิเชียร จิระอนันต์"
+          },
+          {
+            "relate": "Mother",
+            "id": "{{ภัสสร}}",
+            "name": "ภัสสร จิระอนันต์"
+          },
+          {
+            "relate": "Sibling",
+            "id": "{{เอิร์น}}",
+            "name": "เอิร์น จิระอนันต์"
+          },
+          {
+            "relate": "Sibling",
+            "id": "{{เต๋า}}",
+            "name": "เต๋า จิระอนันต์"
+          },
+          {
+            "relate": "Sibling",
+            "id": "{{เต้ย}}",
+            "name": "เต้ย จิระอนันต์"
+          }
+        ],
+        "prename": "",
+        "firstname": "อี้",
+        "lastname": "จิระอนันต์",
+        "sex": "MALE",
+        "houseId": "{{house_id_for_geno}}",
+        "id": "{{อี้}}",
+        "type": "Person",
+        "timestamp": "2018-11-08T11:13:32.353+07:00"
+      },
+      "nodeMargin": 0,
+      "idCard": 183547297,
+      "firstname": "อี้",
+      "lastname": "จิระอนันต์",
+      "gender": "0",
+      "father": 1013365983,
+      "mother": 1607161586
+    },
+    {
+      "linkedStack": [
+        1013365983,
+        1607161586
+      ],
+      "properties": {
+        "identities": [],
+        "chronics": [],
+        "relationships": [
+          {
+            "relate": "Father",
+            "id": "{{วิเชียร}}",
+            "name": "วิเชียร จิระอนันต์"
+          },
+          {
+            "relate": "Mother",
+            "id": "{{ภัสสร}}",
+            "name": "ภัสสร จิระอนันต์"
+          },
+          {
+            "relate": "Sibling",
+            "id": "{{อี้}}",
+            "name": "อี้ จิระอนันต์"
+          },
+          {
+            "relate": "Sibling",
+            "id": "{{เต๋า}}",
+            "name": "เต๋า จิระอนันต์"
+          },
+          {
+            "relate": "Sibling",
+            "id": "{{เต้ย}}",
+            "name": "เต้ย จิระอนันต์"
+          }
+        ],
+        "prename": "",
+        "firstname": "เอิร์น",
+        "lastname": "จิระอนันต์",
+        "sex": "MALE",
+        "houseId": "{{house_id_for_geno}}",
+        "id": "{{เอิร์น}}",
+        "type": "Person",
+        "timestamp": "2018-11-08T11:13:32.353+07:00"
+      },
+      "nodeMargin": 0,
+      "idCard": 752893399,
+      "firstname": "เอิร์น",
+      "lastname": "จิระอนันต์",
+      "gender": "0",
+      "father": 1013365983,
+      "mother": 1607161586
+    },
+    {
+      "linkedStack": [
+        1013365983,
+        1607161586
+      ],
+      "properties": {
+        "identities": [],
+        "chronics": [],
+        "relationships": [
+          {
+            "relate": "Father",
+            "id": "{{วิเชียร}}",
+            "name": "วิเชียร จิระอนันต์"
+          },
+          {
+            "relate": "Mother",
+            "id": "{{ภัสสร}}",
+            "name": "ภัสสร จิระอนันต์"
+          },
+          {
+            "relate": "Sibling",
+            "id": "{{อี้}}",
+            "name": "อี้ จิระอนันต์"
+          },
+          {
+            "relate": "Sibling",
+            "id": "{{เอิร์น}}",
+            "name": "เอิร์น จิระอนันต์"
+          },
+          {
+            "relate": "Sibling",
+            "id": "{{เต๋า}}",
+            "name": "เต๋า จิระอนันต์"
+          }
+        ],
+        "prename": "",
+        "firstname": "เต้ย",
+        "lastname": "จิระอนันต์",
+        "sex": "MALE",
+        "houseId": "{{house_id_for_geno}}",
+        "id": "{{เต้ย}}",
+        "type": "Person",
+        "timestamp": "2018-11-08T11:13:32.353+07:00"
+      },
+      "nodeMargin": 0,
+      "idCard": 1912757006,
+      "firstname": "เต้ย",
+      "lastname": "จิระอนันต์",
+      "gender": "0",
+      "father": 1013365983,
+      "mother": 1607161586
+    },
+    {
+      "linkedStack": [
+        1868639714,
+        356973275
+      ],
+      "properties": {
+        "identities": [],
+        "chronics": [],
+        "relationships": [
+          {
+            "relate": "Father",
+            "id": "{{กรกันต์}}",
+            "name": "กรกันต์ จิระอนันต์"
+          },
+          {
+            "relate": "Mother",
+            "id": "{{น้ำผึ้ง}}",
+            "name": "น้ำผึ้ง จิระอนันต์"
+          },
+          {
+            "relate": "Sibling",
+            "id": "{{เวกัส}}",
+            "name": "เวกัส จิระอนันต์"
+          }
+        ],
+        "prename": "",
+        "firstname": "มาเก๋า",
+        "lastname": "จิระอนันต์",
+        "sex": "MALE",
+        "houseId": "{{house_id_for_geno}}",
+        "id": "{{มาเก๋า}}",
+        "type": "Person",
+        "timestamp": "2018-11-08T11:13:32.353+07:00"
+      },
+      "nodeMargin": 0,
+      "idCard": 1509256505,
+      "firstname": "มาเก๋า",
+      "lastname": "จิระอนันต์",
+      "gender": "0",
+      "father": 1868639714,
+      "mother": 356973275
+    },
+    {
+      "linkedStack": [
+        1013365983,
+        1607161586
+      ],
+      "properties": {
+        "identities": [],
+        "chronics": [],
+        "relationships": [
+          {
+            "relate": "Father",
+            "id": "{{วิเชียร}}",
+            "name": "วิเชียร จิระอนันต์"
+          },
+          {
+            "relate": "Mother",
+            "id": "{{ภัสสร}}",
+            "name": "ภัสสร จิระอนันต์"
+          },
+          {
+            "relate": "Sibling",
+            "id": "{{อี้}}",
+            "name": "อี้ จิระอนันต์"
+          },
+          {
+            "relate": "Sibling",
+            "id": "{{เอิร์น}}",
+            "name": "เอิร์น จิระอนันต์"
+          },
+          {
+            "relate": "Sibling",
+            "id": "{{เต้ย}}",
+            "name": "เต้ย จิระอนันต์"
+          }
+        ],
+        "prename": "",
+        "firstname": "เต๋า",
+        "lastname": "จิระอนันต์",
+        "sex": "MALE",
+        "houseId": "{{house_id_for_geno}}",
+        "id": "{{เต๋า}}",
+        "type": "Person",
+        "timestamp": "2018-11-08T11:13:32.353+07:00"
+      },
+      "nodeMargin": 0,
+      "idCard": 1912831964,
+      "firstname": "เต๋า",
+      "lastname": "จิระอนันต์",
+      "gender": "0",
+      "father": 1013365983,
+      "mother": 1607161586
+    }
+  ]
+}


### PR DESCRIPTION
- Update `fun popChildren()` to order result follow `LinkStack` instead of `member` order in `Family`
- Add **#InFamilyWeTrush2018** case on Android Sample module